### PR TITLE
Document (internally) what RFCs the test-cases are from

### DIFF
--- a/es256_test.go
+++ b/es256_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestVerifyES256(t *testing.T) {
+	// The token and key in this test are from:
+	//
+	// https://tools.ietf.org/html/rfc7515#appendix-A.3
 	s := "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
 
 	encodedX := "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU"

--- a/hs256_test.go
+++ b/hs256_test.go
@@ -11,10 +11,18 @@ import (
 )
 
 func TestVerifyHS256(t *testing.T) {
+	// This key is from:
+	//
+	// https://tools.ietf.org/html/rfc7515#appendix-A.1.1
 	encodedKey := "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
 	key, err := base64.RawURLEncoding.DecodeString(encodedKey)
 	assert.NoError(t, err)
 
+	// This JWT is from:
+	//
+	// https://tools.ietf.org/html/rfc7519#section-3.1
+	//
+	// It also appears in RFC7515.
 	s := "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 
 	var claims map[string]interface{}
@@ -27,6 +35,8 @@ func TestVerifyHS256(t *testing.T) {
 }
 
 func TestSignHS256(t *testing.T) {
+	// We can't reproduce exactly the same JWT that appears in the RFC, because
+	// the RFC uses claims with some weird JSON indentation.
 	encodedKey := "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
 	key, err := base64.RawURLEncoding.DecodeString(encodedKey)
 	assert.NoError(t, err)

--- a/rs256_test.go
+++ b/rs256_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestVerifyRS256(t *testing.T) {
+	// The token and key in this test are from:
+	//
+	// https://tools.ietf.org/html/rfc7515#appendix-A.2
 	s := "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
 
 	encodedN := "ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ"


### PR DESCRIPTION
Doing so makes it easier for others to come along and find more context on where these tests come from -- other codebases use these test-cases, but fail to document their provenance. This makes it seem like these are plucked from thin air, instead of just being clear that they're from RFC7515.